### PR TITLE
Add dynamic service info failover support 

### DIFF
--- a/src/Pulsar.Client/Api/Configuration.fs
+++ b/src/Pulsar.Client/Api/Configuration.fs
@@ -9,7 +9,6 @@ open System.Security.Cryptography.X509Certificates
 
 type PulsarClientConfiguration =
     {
-        ServiceUrl: string
         ServiceAddresses: Uri list
         OperationTimeout: TimeSpan
         StatsInterval: TimeSpan
@@ -32,7 +31,6 @@ type PulsarClientConfiguration =
     }
     static member Default =
         {
-            ServiceUrl = ""
             ServiceAddresses = List.empty<Uri>
             OperationTimeout = TimeSpan.FromMilliseconds(30000.0)
             StatsInterval = TimeSpan.Zero

--- a/src/Pulsar.Client/Api/Configuration.fs
+++ b/src/Pulsar.Client/Api/Configuration.fs
@@ -9,6 +9,7 @@ open System.Security.Cryptography.X509Certificates
 
 type PulsarClientConfiguration =
     {
+        ServiceUrl: string
         ServiceAddresses: Uri list
         OperationTimeout: TimeSpan
         StatsInterval: TimeSpan
@@ -27,9 +28,11 @@ type PulsarClientConfiguration =
         InitialBackoffInterval: TimeSpan
         MaxBackoffInterval: TimeSpan
         KeepAliveInterval: TimeSpan
+        ServiceInfoProvider: ServiceInfoProvider option
     }
     static member Default =
         {
+            ServiceUrl = ""
             ServiceAddresses = List.empty<Uri>
             OperationTimeout = TimeSpan.FromMilliseconds(30000.0)
             StatsInterval = TimeSpan.Zero
@@ -48,6 +51,7 @@ type PulsarClientConfiguration =
             InitialBackoffInterval = TimeSpan.FromMilliseconds(100.0)
             MaxBackoffInterval = TimeSpan.FromSeconds(60.0)
             KeepAliveInterval = TimeSpan.FromSeconds(30.0)
+            ServiceInfoProvider = None
         }
 
 type ConsumerConfiguration<'T> =

--- a/src/Pulsar.Client/Api/PulsarClient.fs
+++ b/src/Pulsar.Client/Api/PulsarClient.fs
@@ -30,18 +30,20 @@ type internal PulsarClientMessage =
 
 type PulsarClient internal (config: PulsarClientConfiguration) as this =
 
-    let connectionPool = ConnectionPool(config)
+    let serviceInfoProvider =
+        match config.ServiceInfoProvider with
+        | Some provider -> provider
+        | None -> DefaultServiceInfoProvider(config) :> ServiceInfoProvider
+
+    let serviceInfoManager = ServiceInfoManager(serviceInfoProvider.InitialServiceInfo())
+    let connectionPool = ConnectionPool(config, serviceInfoManager)
     let producers = HashSet<IAsyncDisposable>()
     let consumers = HashSet<IAsyncDisposable>()
     let schemaProviders = Dictionary<CompleteTopicName, MultiVersionSchemaInfoProvider>()
     let mutable clientState = Active
     let autoProduceStubType =  typeof<AutoProduceBytesSchemaStub>
     let autoConsumeStubType =  typeof<AutoConsumeSchemaStub>
-    let lookupService =
-        if config.Scheme = ServiceUri.HTTP_SERVICE then
-            HttpLookupService(config,connectionPool) :> ILookupService
-        else
-            BinaryLookupService(config,connectionPool) :> ILookupService
+    let lookupService = DynamicLookupService(config, connectionPool, serviceInfoManager) :> ILookupService
 
     let transactionClient =
         if config.EnableTransaction then
@@ -102,7 +104,7 @@ type PulsarClient internal (config: PulsarClientConfiguration) as this =
             | Close channel ->
                 match this.ClientState with
                 | Active ->
-                    Log.Logger.LogInformation("Client closing. URL: {0}", config.ServiceAddresses)
+                    Log.Logger.LogInformation("Client closing. URL: {0}", serviceInfoManager.GetCurrent().ServiceUrl)
                     this.ClientState <- Closing
                     let producersTasks = producers |> Seq.map (fun producer -> backgroundTask { return! producer.DisposeAsync() } )
                     let consumerTasks = consumers |> Seq.map (fun consumer -> backgroundTask { return! consumer.DisposeAsync() })
@@ -110,7 +112,6 @@ type PulsarClient internal (config: PulsarClientConfiguration) as this =
                         try
                             let! _ = Task.WhenAll (seq { yield! producersTasks; yield! consumerTasks })
                             schemaProviders |> Seq.iter (fun (KeyValue (_, provider)) -> provider.Close())
-                            config.Authentication.Dispose()
                             tryStopMailbox()
                             channel.SetResult()
                         with ex ->
@@ -123,6 +124,8 @@ type PulsarClient internal (config: PulsarClientConfiguration) as this =
             | Stop ->
                 this.ClientState <- Closed
                 do! connectionPool.CloseAsync()
+                serviceInfoProvider.Dispose()
+                serviceInfoManager.DisposeTrackedResources()
                 transactionClient |> Option.iter _.Close()
                 Log.Logger.LogInformation("Pulsar client stopped")
                 continueLoop <- false
@@ -133,6 +136,15 @@ type PulsarClient internal (config: PulsarClientConfiguration) as this =
             else
                 Log.Logger.LogInformation("PulsarClient mailbox has stopped normally"))
         |> ignore
+
+    do
+        serviceInfoProvider.Initialize(fun serviceInfo ->
+            match this.ClientState with
+            | Active ->
+                serviceInfoManager.Update(serviceInfo)
+                connectionPool.CloseAllConnectionsForServiceChange()
+            | _ ->
+                ())
 
     let removeConsumer = fun consumer -> post mb (RemoveConsumer consumer)
     let addConsumer = fun consumer -> post mb (AddConsumer consumer)
@@ -364,6 +376,8 @@ type PulsarClient internal (config: PulsarClientConfiguration) as this =
         match this.ClientState with
         | PulsarClientState.Closed | PulsarClientState.Closing -> true
         | _ -> false
+
+    member this.ServiceInfo = serviceInfoManager.GetCurrent()
 
     member this.NewProducer() =
         ProducerBuilder(this.CreateProducerAsync, Schema.BYTES())

--- a/src/Pulsar.Client/Api/PulsarClientBuilder.fs
+++ b/src/Pulsar.Client/Api/PulsarClientBuilder.fs
@@ -17,16 +17,23 @@ type PulsarClientBuilder private (config: PulsarClientConfiguration) =
         config
         |> checkValue
             (fun c ->
-                c.ServiceAddresses
-                |> invalidArgIf (fun addresses -> addresses |> List.isEmpty) "Service Url needs to be specified on the PulsarClientBuilder object.")
+                match c.ServiceInfoProvider, String.IsNullOrWhiteSpace c.ServiceUrl with
+                | Some _, false -> invalidArg "config" "ServiceUrl and ServiceInfoProvider cannot be configured together."
+                | None, true -> invalidArg "config" "ServiceUrl or ServiceInfoProvider needs to be specified on the PulsarClientBuilder object."
+                | _ -> ())
 
     new() = PulsarClientBuilder(PulsarClientConfiguration.Default)
 
     member this.ServiceUrl (url: string) =
         match url |> ServiceUri.parse with
         | (Result.Ok serviceUri) ->
-            PulsarClientBuilder { config with ServiceAddresses = serviceUri.Addresses; UseTls = serviceUri.UseTls ; Scheme = serviceUri.Scheme }
+            PulsarClientBuilder { config with ServiceUrl = url; ServiceAddresses = serviceUri.Addresses; UseTls = serviceUri.UseTls ; Scheme = serviceUri.Scheme }
         | (Result.Error message) -> invalidArg null message
+
+    member this.ServiceInfoProvider (serviceInfoProvider: ServiceInfoProvider) =
+        PulsarClientBuilder
+            { config with
+                ServiceInfoProvider = Some (serviceInfoProvider |> invalidArgIfDefault "ServiceInfoProvider can't be null") }
 
     member this.OperationTimeout operationTimeout =
         PulsarClientBuilder

--- a/src/Pulsar.Client/Api/PulsarClientBuilder.fs
+++ b/src/Pulsar.Client/Api/PulsarClientBuilder.fs
@@ -4,7 +4,7 @@ open System
 open Pulsar.Client.Common
 
 
-type PulsarClientBuilder private (config: PulsarClientConfiguration) =
+type PulsarClientBuilder private (config: PulsarClientConfiguration, serviceUrlConfigured: bool) =
 
     [<Literal>]
     let MIN_STATS_INTERVAL_SECONDS = 1
@@ -17,97 +17,72 @@ type PulsarClientBuilder private (config: PulsarClientConfiguration) =
         config
         |> checkValue
             (fun c ->
-                match c.ServiceInfoProvider, String.IsNullOrWhiteSpace c.ServiceUrl with
-                | Some _, false -> invalidArg "config" "ServiceUrl and ServiceInfoProvider cannot be configured together."
-                | None, true -> invalidArg "config" "ServiceUrl or ServiceInfoProvider needs to be specified on the PulsarClientBuilder object."
+                match c.ServiceInfoProvider, c.ServiceAddresses |> List.isEmpty, serviceUrlConfigured with
+                | Some _, _, true -> invalidArg "config" "ServiceUrl and ServiceInfoProvider cannot be configured together."
+                | None, true, _ -> invalidArg "config" "ServiceUrl or ServiceInfoProvider needs to be specified on the PulsarClientBuilder object."
                 | _ -> ())
 
-    new() = PulsarClientBuilder(PulsarClientConfiguration.Default)
+    new() = PulsarClientBuilder(PulsarClientConfiguration.Default, false)
 
     member this.ServiceUrl (url: string) =
         match url |> ServiceUri.parse with
         | (Result.Ok serviceUri) ->
-            PulsarClientBuilder { config with ServiceUrl = url; ServiceAddresses = serviceUri.Addresses; UseTls = serviceUri.UseTls ; Scheme = serviceUri.Scheme }
+            PulsarClientBuilder({ config with ServiceAddresses = serviceUri.Addresses; UseTls = serviceUri.UseTls ; Scheme = serviceUri.Scheme }, true)
         | (Result.Error message) -> invalidArg null message
 
     member this.ServiceInfoProvider (serviceInfoProvider: ServiceInfoProvider) =
-        PulsarClientBuilder
+        PulsarClientBuilder(
             { config with
-                ServiceInfoProvider = Some (serviceInfoProvider |> invalidArgIfDefault "ServiceInfoProvider can't be null") }
+                ServiceInfoProvider = Some (serviceInfoProvider |> invalidArgIfDefault "ServiceInfoProvider can't be null") },
+            serviceUrlConfigured)
 
     member this.OperationTimeout operationTimeout =
-        PulsarClientBuilder
-            { config with
-                OperationTimeout = operationTimeout }
+        PulsarClientBuilder({ config with OperationTimeout = operationTimeout }, serviceUrlConfigured)
 
     member this.MaxNumberOfRejectedRequestPerConnection num =
-        PulsarClientBuilder
-            { config with
-                MaxNumberOfRejectedRequestPerConnection = num |> invalidArgIfLessThanZero "MaxNumberOfRejectedRequestPerConnection can't be negative" }
+        PulsarClientBuilder({ config with MaxNumberOfRejectedRequestPerConnection = num |> invalidArgIfLessThanZero "MaxNumberOfRejectedRequestPerConnection can't be negative" }, serviceUrlConfigured)
 
     member this.EnableTls useTls =
-        PulsarClientBuilder
-            { config with
-                UseTls = useTls }
+        PulsarClientBuilder({ config with UseTls = useTls }, serviceUrlConfigured)
 
     member this.EnableTlsHostnameVerification enableTlsHostnameVerification =
-        PulsarClientBuilder
-            { config with
-                TlsHostnameVerificationEnable = enableTlsHostnameVerification }
+        PulsarClientBuilder({ config with TlsHostnameVerificationEnable = enableTlsHostnameVerification }, serviceUrlConfigured)
 
     member this.AllowTlsInsecureConnection allowTlsInsecureConnection =
-        PulsarClientBuilder
-            { config with
-                TlsAllowInsecureConnection = allowTlsInsecureConnection }
+        PulsarClientBuilder({ config with TlsAllowInsecureConnection = allowTlsInsecureConnection }, serviceUrlConfigured)
 
     member this.TlsTrustCertificate tlsTrustCertificate =
-        PulsarClientBuilder
-            { config with
-                TlsTrustCertificate = tlsTrustCertificate }
+        PulsarClientBuilder({ config with TlsTrustCertificate = tlsTrustCertificate }, serviceUrlConfigured)
             
     member this.TlsCertificate tlsCertificate =
-        PulsarClientBuilder
-            { config with
-                TlsCertificate = tlsCertificate }
+        PulsarClientBuilder({ config with TlsCertificate = tlsCertificate }, serviceUrlConfigured)
 
     member this.Authentication authentication =
-        PulsarClientBuilder
-            { config with
-                Authentication = authentication |> invalidArgIfDefault "Authentication can't be null" }
+        PulsarClientBuilder({ config with Authentication = authentication |> invalidArgIfDefault "Authentication can't be null" }, serviceUrlConfigured)
 
     member this.TlsProtocols protocol =
-        PulsarClientBuilder
-            { config with
-                TlsProtocols = protocol }
+        PulsarClientBuilder({ config with TlsProtocols = protocol }, serviceUrlConfigured)
 
     member this.StatsInterval interval =
-        PulsarClientBuilder
-            { config with
-                StatsInterval = interval |> invalidArgIf (fun arg ->
-                arg <> TimeSpan.Zero && arg < TimeSpan.FromSeconds(float MIN_STATS_INTERVAL_SECONDS)) (sprintf "Stats interval should be greater than %i s" MIN_STATS_INTERVAL_SECONDS) }
+        PulsarClientBuilder({ config with
+                                StatsInterval = interval |> invalidArgIf (fun arg ->
+                                arg <> TimeSpan.Zero && arg < TimeSpan.FromSeconds(float MIN_STATS_INTERVAL_SECONDS)) (sprintf "Stats interval should be greater than %i s" MIN_STATS_INTERVAL_SECONDS) }, serviceUrlConfigured)
 
     member this.ListenerName name =
-        PulsarClientBuilder
-            { config with
-                ListenerName =
-                    name
-                    |> invalidArgIfBlankString "Param listenerName must not be blank."
-                    |> _.Trim() }
+        PulsarClientBuilder({ config with
+                                ListenerName =
+                                    name
+                                    |> invalidArgIfBlankString "Param listenerName must not be blank."
+                                    |> _.Trim() }, serviceUrlConfigured)
 
     member this.MaxLookupRedirects maxLookupRedirects =
-        PulsarClientBuilder
-            { config with
-                MaxLookupRedirects = maxLookupRedirects }
+        PulsarClientBuilder({ config with MaxLookupRedirects = maxLookupRedirects }, serviceUrlConfigured)
 
     member this.EnableTransaction enableTransaction =
-        PulsarClientBuilder
-            { config with
-                EnableTransaction = enableTransaction }
+        PulsarClientBuilder({ config with EnableTransaction = enableTransaction }, serviceUrlConfigured)
 
     member this.KeepAliveInterval keepAliveInterval =
-        PulsarClientBuilder
-            { config with
-                KeepAliveInterval = keepAliveInterval }
+        PulsarClientBuilder({ config with KeepAliveInterval = keepAliveInterval }, serviceUrlConfigured)
 
     member this.BuildAsync() =
         let client =

--- a/src/Pulsar.Client/Api/ServiceInfo.fs
+++ b/src/Pulsar.Client/Api/ServiceInfo.fs
@@ -1,0 +1,39 @@
+namespace Pulsar.Client.Api
+
+open System
+open System.Security.Cryptography.X509Certificates
+open Pulsar.Client.Common
+
+type ServiceInfo(serviceUrl: string,
+                 authentication: Authentication,
+                 ?tlsTrustCertificate: X509Certificate2,
+                 ?tlsCertificate: X509Certificate2,
+                 ?useTls: bool) =
+
+    let parsed =
+        match ServiceUri.parse serviceUrl with
+        | Ok serviceUri -> serviceUri
+        | Error message -> invalidArg "serviceUrl" message
+
+    let authentication =
+        authentication
+        |> invalidArgIfDefault "authentication can't be null"
+
+    let tlsTrustCertificate = defaultArg tlsTrustCertificate null
+    let tlsCertificate = defaultArg tlsCertificate null
+    let useTls = defaultArg useTls parsed.UseTls
+
+    member _.ServiceUrl = serviceUrl
+    member _.Authentication = authentication
+    member _.TlsTrustCertificate = tlsTrustCertificate
+    member _.TlsCertificate = tlsCertificate
+    member _.UseTls = useTls
+    member _.Scheme = parsed.Scheme
+    member _.ServiceAddresses = parsed.Addresses
+
+    new(serviceUrl: string) =
+        ServiceInfo(serviceUrl, Authentication.AuthenticationDisabled)
+
+    new(serviceUrl: string, authentication: Authentication) =
+        ServiceInfo(serviceUrl, authentication, null, null)
+

--- a/src/Pulsar.Client/Api/ServiceInfoProvider.fs
+++ b/src/Pulsar.Client/Api/ServiceInfoProvider.fs
@@ -1,0 +1,18 @@
+namespace Pulsar.Client.Api
+
+open System
+
+[<AbstractClass>]
+type ServiceInfoProvider() =
+
+    abstract member InitialServiceInfo: unit -> ServiceInfo
+
+    abstract member Initialize: (ServiceInfo -> unit) -> unit
+    default _.Initialize _ = ()
+
+    abstract member Dispose: unit -> unit
+    default _.Dispose () = ()
+
+    interface IDisposable with
+        member this.Dispose() = this.Dispose()
+

--- a/src/Pulsar.Client/Common/ServiceUri.fs
+++ b/src/Pulsar.Client/Common/ServiceUri.fs
@@ -81,3 +81,30 @@ module internal ServiceUri =
                 let addresses = hosts |> Seq.map (createBuilder >> rewritePort >> dropUserInfo >> getUri) |> List.ofSeq
 
                 Ok { OriginalString = str; Addresses = addresses; UseTls = useTls; Scheme = scheme }
+
+    let build (scheme: string) (useTls: bool) (addresses: Uri list) =
+        if List.isEmpty addresses then
+            invalidArg "addresses" "Addresses list could not be empty."
+
+        let fullScheme =
+            match scheme, useTls with
+            | value, true when value = BINARY_SERVICE -> "pulsar+ssl"
+            | value, true when value = HTTP_SERVICE -> "http+ssl"
+            | value, false when value = BINARY_SERVICE -> BINARY_SERVICE
+            | value, false when value = HTTP_SERVICE -> HTTP_SERVICE
+            | _ -> invalidArg "scheme" (sprintf "Unsupported scheme '%s'." scheme)
+
+        let authorities =
+            addresses
+            |> Seq.map (fun uri ->
+                let builder = UriBuilder(uri)
+                builder.Scheme <- fullScheme
+                builder.Path <- ""
+                builder.Query <- ""
+                builder.Fragment <- ""
+                builder.UserName <- null
+                builder.Password <- null
+                builder.Uri.Authority)
+            |> String.concat ","
+
+        $"{fullScheme}://{authorities}"

--- a/src/Pulsar.Client/Internal/BinaryLookupService.fs
+++ b/src/Pulsar.Client/Internal/BinaryLookupService.fs
@@ -7,9 +7,11 @@ open System
 open System.Net
 open Microsoft.Extensions.Logging
 
-type internal BinaryLookupService (config: PulsarClientConfiguration, connectionPool: ConnectionPool) =
+type internal BinaryLookupService (config: PulsarClientConfiguration,
+                                   connectionPool: ConnectionPool,
+                                   serviceInfoManager: ServiceInfoManager) =
 
-    let endPointResolver = EndPointResolver(config.ServiceAddresses)
+    let endPointResolver = DynamicEndPointResolver(fun () -> serviceInfoManager.GetCurrent().ServiceAddresses)
 
     let resolveEndPoint() = endPointResolver.Resolve()
 
@@ -107,9 +109,10 @@ type internal BinaryLookupService (config: PulsarClientConfiguration, connection
             let payload = Commands.newLookup topicName requestId authoritative config.ListenerName
             let! response = clientCnx.SendAndWaitForReply requestId payload
             let lookupTopicResult = PulsarResponseType.GetLookupTopicResult response
+            let serviceInfo = serviceInfoManager.GetCurrent()
             // (1) build response broker-address
             let uri =
-                if config.UseTls then
+                if serviceInfo.UseTls then
                     Uri(lookupTopicResult.BrokerServiceUrlTls)
                 else
                     Uri(lookupTopicResult.BrokerServiceUrl)

--- a/src/Pulsar.Client/Internal/BinaryLookupService.fs
+++ b/src/Pulsar.Client/Internal/BinaryLookupService.fs
@@ -11,7 +11,7 @@ type internal BinaryLookupService (config: PulsarClientConfiguration,
                                    connectionPool: ConnectionPool,
                                    serviceInfoManager: ServiceInfoManager) =
 
-    let endPointResolver = DynamicEndPointResolver(fun () -> serviceInfoManager.GetCurrent().ServiceAddresses)
+    let endPointResolver = EndPointResolver(fun () -> serviceInfoManager.GetCurrent().ServiceAddresses)
 
     let resolveEndPoint() = endPointResolver.Resolve()
 

--- a/src/Pulsar.Client/Internal/ClientCnx.fs
+++ b/src/Pulsar.Client/Internal/ClientCnx.fs
@@ -112,6 +112,7 @@ and internal SocketMessage =
     | Stop
 
 and internal ClientCnx (config: PulsarClientConfiguration,
+                serviceInfo: ServiceInfo,
                 broker: Broker,
                 connection: Connection,
                 maxMessageSize: int,
@@ -128,7 +129,7 @@ and internal ClientCnx (config: PulsarClientConfiguration,
     let (PhysicalAddress physicalAddress) = broker.PhysicalAddress
     let (LogicalAddress logicalAddress) = broker.LogicalAddress
     let proxyToBroker = if physicalAddress = logicalAddress then None else Some logicalAddress
-    let mutable authenticationDataProvider = config.Authentication.GetAuthData(physicalAddress.Host);
+    let mutable authenticationDataProvider = serviceInfo.Authentication.GetAuthData(physicalAddress.Host);
 
     let consumers = Dictionary<ConsumerId, ConsumerOperations>()
     let producers = Dictionary<ProducerId, ProducerOperations>()
@@ -783,8 +784,8 @@ and internal ClientCnx (config: PulsarClientConfiguration,
             if cmd.Challenge |> isNull |> not then
                 if (cmd.Challenge.auth_data |> Array.compareWith Operators.compare AuthData.REFRESH_AUTH_DATA_BYTES) = 0 then
                     Log.Logger.LogDebug("{0} Refreshed authentication provider", prefix)
-                    authenticationDataProvider <- config.Authentication.GetAuthData(physicalAddress.Host)
-                let methodName = config.Authentication.GetAuthMethodName()
+                    authenticationDataProvider <- serviceInfo.Authentication.GetAuthData(physicalAddress.Host)
+                let methodName = serviceInfo.Authentication.GetAuthMethodName()
                 let authData = authenticationDataProvider.Authenticate({ Bytes = cmd.Challenge.auth_data })
                 let request = Commands.newAuthResponse methodName authData (int protocolVersion) clientVersion
                 Log.Logger.LogInformation("{0} Mutual auth {1}, requested {2}", prefix, methodName, cmd.Challenge.AuthMethodName)
@@ -876,7 +877,7 @@ and internal ClientCnx (config: PulsarClientConfiguration,
 
     member internal this.NewConnectCommand() =
         let authData = authenticationDataProvider.Authenticate(AuthData.INIT_AUTH_DATA)
-        let authMethodName = config.Authentication.GetAuthMethodName()
+        let authMethodName = serviceInfo.Authentication.GetAuthMethodName()
         Commands.newConnect authMethodName authData clientVersion protocolVersion proxyToBroker
 
     member this.Send payload =

--- a/src/Pulsar.Client/Internal/ConnectionPool.fs
+++ b/src/Pulsar.Client/Internal/ConnectionPool.fs
@@ -14,7 +14,7 @@ open System.Net.Sockets
 open System.Net.Security
 open System.Security.Cryptography.X509Certificates
 
-type internal ConnectionPool (config: PulsarClientConfiguration) =
+type internal ConnectionPool (config: PulsarClientConfiguration, serviceInfoManager: ServiceInfoManager) =
 
 
     let connections = ConcurrentDictionary<LogicalAddress, Lazy<Task<ClientCnx>>>()
@@ -57,9 +57,9 @@ type internal ConnectionPool (config: PulsarClientConfiguration) =
         |> Seq.map (fun cs -> string cs.Status)
         |> String.concat "|"
 
-    let remoteCertificateValidationCallback (_: obj) (cert: X509Certificate) (_: X509Chain) (errors: SslPolicyErrors) =
+    let remoteCertificateValidationCallback (serviceInfo: ServiceInfo) (_: obj) (cert: X509Certificate) (_: X509Chain) (errors: SslPolicyErrors) =
         let CheckRemoteCertWithTrustCertificate() =
-            if isNull config.TlsTrustCertificate then
+            if isNull serviceInfo.TlsTrustCertificate then
                 false
             else
                 let chain = new X509Chain()
@@ -69,7 +69,7 @@ type internal ConnectionPool (config: PulsarClientConfiguration) =
                     X509VerificationFlags.IgnoreCertificateAuthorityRevocationUnknown +
                     X509VerificationFlags.IgnoreRootRevocationUnknown
                 chain.ChainPolicy.RevocationMode <- X509RevocationMode.NoCheck
-                let ca = config.TlsTrustCertificate
+                let ca = serviceInfo.TlsTrustCertificate
                 chain.ChainPolicy.ExtraStore.Add ca |> ignore
                 use cert2 = new X509Certificate2(cert)
                 if chain.Build(cert2) then
@@ -134,6 +134,7 @@ type internal ConnectionPool (config: PulsarClientConfiguration) =
                                   broker, maxMessageSize)
         backgroundTask {
             let (PhysicalAddress physicalAddress) = broker.PhysicalAddress
+            let serviceInfo = serviceInfoManager.GetCurrent()
             // We should use PipeOptions.Default.PauseWriterThreshold as the minimum value for pauseWriterThreshold. A value that's too small isn't practical and will affect performance.
             let pauseWriterThreshold = max (int64 maxMessageSize) PipeOptions.Default.PauseWriterThreshold
             // Make sure the resumeWriterThreshold is half of the pauseWriterThreshold for better performance: https://github.com/dotnet/runtime/blob/970070e3b78b8cf604dabfe114e1f609c38c555d/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeOptions.cs#L50-L51
@@ -144,15 +145,15 @@ type internal ConnectionPool (config: PulsarClientConfiguration) =
             try
                 let! connection =
                     backgroundTask {
-                        if config.UseTls then
+                        if serviceInfo.UseTls then
                             Log.Logger.LogDebug("Configuring ssl for {0}", physicalAddress)
-                            let sslStream = new SslStream(new NetworkStream(socket), false, RemoteCertificateValidationCallback(remoteCertificateValidationCallback))
-                            let authData = config.Authentication.GetAuthData(physicalAddress.Host)
+                            let sslStream = new SslStream(new NetworkStream(socket), false, RemoteCertificateValidationCallback(remoteCertificateValidationCallback serviceInfo))
+                            let authData = serviceInfo.Authentication.GetAuthData(physicalAddress.Host)
                             let clientCertificates =
                                 if authData.HasDataForTls() then
-                                    config.Authentication.GetAuthData(physicalAddress.Host).GetTlsCertificates()
+                                    serviceInfo.Authentication.GetAuthData(physicalAddress.Host).GetTlsCertificates()
                                 else
-                                    let clientCert = config.TlsCertificate
+                                    let clientCert = serviceInfo.TlsCertificate
                                     if clientCert = null then
                                         X509Certificate2Collection()
                                     elif not clientCert.HasPrivateKey then
@@ -180,7 +181,7 @@ type internal ConnectionPool (config: PulsarClientConfiguration) =
                 Log.Logger.LogDebug("Connection established for {0}", physicalAddress)
                 let initialConnectionTsc = TaskCompletionSource<ClientCnx>(TaskCreationOptions.RunContinuationsAsynchronously)
 
-                let clientCnx = ClientCnx(config, broker, connection, maxMessageSize, initialConnectionTsc,
+                let clientCnx = ClientCnx(config, serviceInfo, broker, connection, maxMessageSize, initialConnectionTsc,
                                           unregisterClientCnx)
                 let connectPayload = clientCnx.NewConnectCommand()
                 let! success = clientCnx.Send connectPayload
@@ -215,6 +216,21 @@ type internal ConnectionPool (config: PulsarClientConfiguration) =
     member this.GetBasicConnection (address: DnsEndPoint) =
         this.GetConnection({ LogicalAddress = LogicalAddress address; PhysicalAddress = PhysicalAddress address },
                            Commands.DEFAULT_MAX_MESSAGE_SIZE)
+
+    member this.CloseAllConnectionsForServiceChange() =
+        backgroundTask {
+            for KeyValue(key, connectionTask) in connections.ToArray() do
+                match connections.TryRemove(key) with
+                | true, _ ->
+                    try
+                        let! cnx = connectionTask.Value
+                        cnx.Dispose()
+                    with ex ->
+                        Log.Logger.LogDebug(ex, "Couldn't get connection on service change for {0}", key)
+                | false, _ ->
+                    ()
+        }
+        |> ignore
 
     member this.CloseAsync() =
         backgroundTask {

--- a/src/Pulsar.Client/Internal/DefaultServiceInfoProvider.fs
+++ b/src/Pulsar.Client/Internal/DefaultServiceInfoProvider.fs
@@ -1,16 +1,13 @@
 namespace Pulsar.Client.Internal
 
-open System
 open Pulsar.Client.Api
+open Pulsar.Client.Common
 
 type internal DefaultServiceInfoProvider(config: PulsarClientConfiguration) =
     inherit ServiceInfoProvider()
 
     let getServiceUrl() =
-        if String.IsNullOrWhiteSpace config.ServiceUrl then
-            invalidArg "config.ServiceUrl" "ServiceUrl needs to be specified when ServiceInfoProvider is not configured."
-
-        config.ServiceUrl
+        ServiceUri.build config.Scheme config.UseTls config.ServiceAddresses
 
     override _.InitialServiceInfo() =
         ServiceInfo(getServiceUrl(), config.Authentication, config.TlsTrustCertificate, config.TlsCertificate, config.UseTls)

--- a/src/Pulsar.Client/Internal/DefaultServiceInfoProvider.fs
+++ b/src/Pulsar.Client/Internal/DefaultServiceInfoProvider.fs
@@ -1,0 +1,17 @@
+namespace Pulsar.Client.Internal
+
+open System
+open Pulsar.Client.Api
+
+type internal DefaultServiceInfoProvider(config: PulsarClientConfiguration) =
+    inherit ServiceInfoProvider()
+
+    let getServiceUrl() =
+        if String.IsNullOrWhiteSpace config.ServiceUrl then
+            invalidArg "config.ServiceUrl" "ServiceUrl needs to be specified when ServiceInfoProvider is not configured."
+
+        config.ServiceUrl
+
+    override _.InitialServiceInfo() =
+        ServiceInfo(getServiceUrl(), config.Authentication, config.TlsTrustCertificate, config.TlsCertificate, config.UseTls)
+

--- a/src/Pulsar.Client/Internal/DynamicLookupService.fs
+++ b/src/Pulsar.Client/Internal/DynamicLookupService.fs
@@ -1,0 +1,36 @@
+namespace Pulsar.Client.Internal
+
+open System.Threading.Tasks
+open Pulsar.Client.Api
+open Pulsar.Client.Common
+
+type internal DynamicLookupService(config: PulsarClientConfiguration,
+                                   connectionPool: ConnectionPool,
+                                   serviceInfoManager: ServiceInfoManager) =
+
+    let binaryLookupService = BinaryLookupService(config, connectionPool, serviceInfoManager) :> ILookupService
+    let httpLookupService = HttpLookupService(config, connectionPool, serviceInfoManager) :> ILookupService
+
+    let getLookupService() =
+        let serviceInfo = serviceInfoManager.GetCurrent()
+        if serviceInfo.Scheme = ServiceUri.HTTP_SERVICE then
+            httpLookupService
+        else
+            binaryLookupService
+
+    interface ILookupService with
+
+        member _.GetPartitionsForTopic(topicName: TopicName) : Task<TopicName[]> =
+            (getLookupService()).GetPartitionsForTopic(topicName)
+
+        member _.GetPartitionedTopicMetadata(topicName: CompleteTopicName) : Task<PartitionedTopicMetadata> =
+            (getLookupService()).GetPartitionedTopicMetadata(topicName)
+
+        member _.GetBroker(topicName: CompleteTopicName) : Task<Broker> =
+            (getLookupService()).GetBroker(topicName)
+
+        member _.GetTopicsUnderNamespace(ns: NamespaceName, isPersistent: bool) : Task<string[]> =
+            (getLookupService()).GetTopicsUnderNamespace(ns, isPersistent)
+
+        member _.GetSchema(topicName: CompleteTopicName, ?schema: SchemaVersion) : Task<TopicSchema option> =
+            (getLookupService()).GetSchema(topicName, ?schema = schema)

--- a/src/Pulsar.Client/Internal/EndPointResolver.fs
+++ b/src/Pulsar.Client/Internal/EndPointResolver.fs
@@ -15,3 +15,16 @@ type internal EndPointResolver(addresses : Uri list) =
         let index = Interlocked.Increment(&currentIndex)
         let uri = addresses.[index % addresses.Length]
         DnsEndPoint(uri.Host, uri.Port)
+
+type internal DynamicEndPointResolver(addressProvider: unit -> Uri list) =
+    let mutable currentIndex = -1
+
+    member _.Resolve() =
+        let addresses = addressProvider()
+
+        if List.isEmpty addresses then
+            invalidArg "addresses" "Addresses list could not be empty."
+
+        let index = Interlocked.Increment(&currentIndex)
+        let uri = addresses.[index % addresses.Length]
+        DnsEndPoint(uri.Host, uri.Port)

--- a/src/Pulsar.Client/Internal/EndPointResolver.fs
+++ b/src/Pulsar.Client/Internal/EndPointResolver.fs
@@ -4,24 +4,11 @@ open System
 open System.Net
 open System.Threading
 
-type internal EndPointResolver(addresses : Uri list) =
-    let mutable currentIndex = -1
-    
-    do
-        if List.isEmpty addresses then
-            invalidArg "addresses" "Addresses list could not be empty."
-            
-    member this.Resolve() =
-        let index = Interlocked.Increment(&currentIndex)
-        let uri = addresses.[index % addresses.Length]
-        DnsEndPoint(uri.Host, uri.Port)
-
-type internal DynamicEndPointResolver(addressProvider: unit -> Uri list) =
+type internal EndPointResolver(addressProvider: unit -> Uri list) =
     let mutable currentIndex = -1
 
     member _.Resolve() =
         let addresses = addressProvider()
-
         if List.isEmpty addresses then
             invalidArg "addresses" "Addresses list could not be empty."
 

--- a/src/Pulsar.Client/Internal/HttpLookupService.fs
+++ b/src/Pulsar.Client/Internal/HttpLookupService.fs
@@ -12,9 +12,15 @@ open System.Text.Json
 open Microsoft.Extensions.Logging
 open Pulsar.Client.Schema
 
-type internal HttpLookupService (config: PulsarClientConfiguration, _connectionPool: ConnectionPool) =
+type internal HttpLookupService (config: PulsarClientConfiguration,
+                                 _connectionPool: ConnectionPool,
+                                 serviceInfoManager: ServiceInfoManager) =
 
-    let pulsarHttpClient = PulsarHttpClient(config)
+    let pulsarHttpClient = PulsarHttpClient(serviceInfoManager)
+
+    let getRandomServiceUri() =
+        let addresses = serviceInfoManager.GetCurrent().ServiceAddresses
+        addresses[RandomGenerator.Next(0, addresses.Length)]
 
     interface ILookupService with
 
@@ -52,7 +58,7 @@ type internal HttpLookupService (config: PulsarClientConfiguration, _connectionP
         //  GET /lookup/v2/topic/{topic-domain}/{tenant}/{namespace}/{topic}
         member this.GetBroker(topicName : CompleteTopicName) =
             backgroundTask {
-                let randomServiceUri = config.ServiceAddresses[RandomGenerator.Next(0, config.ServiceAddresses.Length)]
+                let randomServiceUri = getRandomServiceUri()
                 let topic: string = %topicName
                 let topicRestPath = topic.Replace("persistent://","persistent/").Replace("non-persistent://","non-persistent/")
                 let! brokerResponse =
@@ -61,8 +67,9 @@ type internal HttpLookupService (config: PulsarClientConfiguration, _connectionP
                                                BrokerUrlTls: string;
                                                HttpUrl: string;
                                                HttpUrlTls: string |}>
+                let serviceInfo = serviceInfoManager.GetCurrent()
                 let uri =
-                    if config.UseTls then
+                    if serviceInfo.UseTls then
                         Uri(brokerResponse.BrokerUrlTls)
                     else
                         Uri(brokerResponse.BrokerUrl)
@@ -98,7 +105,7 @@ type internal HttpLookupService (config: PulsarClientConfiguration, _connectionP
     member private this.GetPartitionedTopicMetadataInner (topicName: CompleteTopicName, backoff: Backoff, remainingTimeMs) =
          async {
             try
-                let randomServiceUri = config.ServiceAddresses[RandomGenerator.Next(0, config.ServiceAddresses.Length)]
+                let randomServiceUri = getRandomServiceUri()
                 let topic: string = %topicName
                 let topicRestPath = topic.Replace("persistent://","persistent/").Replace("non-persistent://","non-persistent/")
                 let! brokerResponse =
@@ -121,7 +128,7 @@ type internal HttpLookupService (config: PulsarClientConfiguration, _connectionP
     member private this.GetTopicsUnderNamespaceInner (ns: NamespaceName, backoff: Backoff, remainingTimeMs: int, isPersistent: bool) =
         async {
             try
-                let randomServiceUri = config.ServiceAddresses[RandomGenerator.Next(0, config.ServiceAddresses.Length)]
+                let randomServiceUri = getRandomServiceUri()
                 let mode =
                     match isPersistent with
                     | true -> "PERSISTENT"
@@ -147,7 +154,7 @@ type internal HttpLookupService (config: PulsarClientConfiguration, _connectionP
                               backoff: Backoff, remainingTimeMs: int) =
         async {
             try
-                let randomServiceUri = config.ServiceAddresses[RandomGenerator.Next(0, config.ServiceAddresses.Length)]
+                let randomServiceUri = getRandomServiceUri()
                 let topic: string = %topicName
                 let topicRestPath = topic.Replace("persistent://","").Replace("non-persistent://","")
                 let path =

--- a/src/Pulsar.Client/Internal/PulsarHttpClient.fs
+++ b/src/Pulsar.Client/Internal/PulsarHttpClient.fs
@@ -4,14 +4,11 @@ open System.Net.Http
 open System.Net.Http.Json
 open System.Text.Json
 open System.Text.Json.Serialization
-open Pulsar.Client.Api
 open System
 
 //  This class is mainly used for http lookup service
 //  We name this class `PulsarHttpClient` to avoid naming clash with native HttpClient, and in Java pulsar client it's just `HttpClient`
-type internal PulsarHttpClient (config: PulsarClientConfiguration) =
-
-    let authenticationDataProvider = config.Authentication.GetAuthData()
+type internal PulsarHttpClient (serviceInfoManager: ServiceInfoManager) =
 
     let jsonOptions = JsonSerializerOptions(
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
@@ -25,6 +22,7 @@ type internal PulsarHttpClient (config: PulsarClientConfiguration) =
 
     member this.Get<'T> (requestUri: string) =
         backgroundTask {
+            let authenticationDataProvider = serviceInfoManager.GetCurrent().Authentication.GetAuthData()
             if authenticationDataProvider.HasDataForHttp() then
                 let request = new HttpRequestMessage(HttpMethod.Get, requestUri)
                 for headerPropertyEntry in authenticationDataProvider.GetHttpHeaders() do

--- a/src/Pulsar.Client/Internal/ServiceInfoManager.fs
+++ b/src/Pulsar.Client/Internal/ServiceInfoManager.fs
@@ -1,0 +1,34 @@
+namespace Pulsar.Client.Internal
+
+open System.Collections.Generic
+open System.Security.Cryptography.X509Certificates
+open System.Threading
+open Pulsar.Client.Api
+
+type internal ServiceInfoManager(initialServiceInfo: ServiceInfo) =
+
+    let trackedServiceInfos = ResizeArray<ServiceInfo>()
+    let mutable current = initialServiceInfo
+
+    do trackedServiceInfos.Add(initialServiceInfo)
+
+    member _.GetCurrent() =
+        Volatile.Read(&current)
+
+    member _.Update(serviceInfo: ServiceInfo) =
+        trackedServiceInfos.Add(serviceInfo)
+        Interlocked.Exchange(&current, serviceInfo) |> ignore
+
+    member _.DisposeTrackedResources() =
+        let auths = HashSet<Authentication>(HashIdentity.Reference)
+        let certificates = HashSet<X509Certificate2>(HashIdentity.Reference)
+
+        for serviceInfo in trackedServiceInfos do
+            if auths.Add(serviceInfo.Authentication) then
+                serviceInfo.Authentication.Dispose()
+
+            if not (isNull serviceInfo.TlsTrustCertificate) && certificates.Add(serviceInfo.TlsTrustCertificate) then
+                serviceInfo.TlsTrustCertificate.Dispose()
+
+            if not (isNull serviceInfo.TlsCertificate) && certificates.Add(serviceInfo.TlsCertificate) then
+                serviceInfo.TlsCertificate.Dispose()

--- a/src/Pulsar.Client/Pulsar.Client.fsproj
+++ b/src/Pulsar.Client/Pulsar.Client.fsproj
@@ -85,6 +85,8 @@
     <Compile Include="Common\ConsumerBase.fs" />
     <Compile Include="Api\AuthenticationDataProvider.fs" />
     <Compile Include="Api\Authentication.fs" />
+    <Compile Include="Api\ServiceInfo.fs" />
+    <Compile Include="Api\ServiceInfoProvider.fs" />
     <Compile Include="Api\IMessageRouter.fs" />
     <Compile Include="Api\IConsumer.fs" />
     <Compile Include="Api\IReader.fs" />
@@ -135,12 +137,15 @@
     <Compile Include="Internal\UnAckedMessageTracker.fs" />
     <Compile Include="Internal\NegativeAcksTracker.fs" />
     <Compile Include="Internal\ClientCnx.fs" />
+    <Compile Include="Internal\ServiceInfoManager.fs" />
+    <Compile Include="Internal\DefaultServiceInfoProvider.fs" />
     <Compile Include="Internal\ConnectionPool.fs" />
     <Compile Include="Internal\EndPointResolver.fs" />
     <Compile Include="Internal\ILookupService.fs" />
     <Compile Include="Internal\BinaryLookupService.fs" />
     <Compile Include="Internal\PulsarHttpClient.fs" />
     <Compile Include="Internal\HttpLookupService.fs" />
+    <Compile Include="Internal\DynamicLookupService.fs" />
     <Compile Include="Internal\ConnectionHandler.fs" />
     <Compile Include="Internal\AcknowledgmentsGroupingTracker.fs" />
     <Compile Include="Internal\ProducerImpl.fs" />

--- a/tests/UnitTests/Api/ConsumerBuilderTests.fs
+++ b/tests/UnitTests/Api/ConsumerBuilderTests.fs
@@ -10,7 +10,9 @@ open Pulsar.Client.Common
 module ConsumerBuilderTests =
 
     let private builder() =
-        PulsarClient({ PulsarClientConfiguration.Default with ServiceAddresses = [ Uri("pulsar://localhost:6650") ] }).NewConsumer()
+        PulsarClient({ PulsarClientConfiguration.Default with
+                            ServiceUrl = "pulsar://localhost:6650"
+                            ServiceAddresses = [ Uri("pulsar://localhost:6650") ] }).NewConsumer()
 
     let configure builderF builder =
         fun() ->  builder |> builderF |> ignore

--- a/tests/UnitTests/Api/ConsumerBuilderTests.fs
+++ b/tests/UnitTests/Api/ConsumerBuilderTests.fs
@@ -11,7 +11,6 @@ module ConsumerBuilderTests =
 
     let private builder() =
         PulsarClient({ PulsarClientConfiguration.Default with
-                            ServiceUrl = "pulsar://localhost:6650"
                             ServiceAddresses = [ Uri("pulsar://localhost:6650") ] }).NewConsumer()
 
     let configure builderF builder =

--- a/tests/UnitTests/Api/ProducerBuilderTests.fs
+++ b/tests/UnitTests/Api/ProducerBuilderTests.fs
@@ -10,7 +10,9 @@ open Pulsar.Client.Common
 module ProducerBuilderTests =
 
     let private builder() =
-        PulsarClient({ PulsarClientConfiguration.Default with ServiceAddresses = [ Uri("pulsar://localhost:6650") ] }).NewProducer()
+        PulsarClient({ PulsarClientConfiguration.Default with
+                            ServiceUrl = "pulsar://localhost:6650"
+                            ServiceAddresses = [ Uri("pulsar://localhost:6650") ] }).NewProducer()
 
     let configure builderF builder =
         fun() ->  builder |> builderF |> ignore

--- a/tests/UnitTests/Api/ProducerBuilderTests.fs
+++ b/tests/UnitTests/Api/ProducerBuilderTests.fs
@@ -11,7 +11,6 @@ module ProducerBuilderTests =
 
     let private builder() =
         PulsarClient({ PulsarClientConfiguration.Default with
-                            ServiceUrl = "pulsar://localhost:6650"
                             ServiceAddresses = [ Uri("pulsar://localhost:6650") ] }).NewProducer()
 
     let configure builderF builder =

--- a/tests/UnitTests/Api/PulsarClientBuilderTests.fs
+++ b/tests/UnitTests/Api/PulsarClientBuilderTests.fs
@@ -8,6 +8,19 @@ open Pulsar.Client.UnitTests
 
 module PulsarClientBuilderTests =
 
+    type private ManualServiceInfoProvider(initial: ServiceInfo) =
+        inherit ServiceInfoProvider()
+
+        let mutable onUpdate = ignore
+
+        member _.Update(serviceInfo: ServiceInfo) =
+            onUpdate serviceInfo
+
+        override _.InitialServiceInfo() = initial
+
+        override _.Initialize(callback) =
+            onUpdate <- callback
+
     let private builder() =
         PulsarClientBuilder()
 
@@ -36,7 +49,21 @@ module PulsarClientBuilderTests =
             test "Build throws an exception if ServiceUrl is empty" {
                 fun() -> builder().BuildAsync() |> ignore
                 |> Expect.throwsWithMessage<ArgumentException>
-                    "Service Url needs to be specified on the PulsarClientBuilder object."
+                    "ServiceUrl or ServiceInfoProvider needs to be specified on the PulsarClientBuilder object. (Parameter 'config')"
+            }
+
+            testTask "Build works with ServiceInfoProvider only" {
+                let provider = ManualServiceInfoProvider(ServiceInfo("pulsar://localhost:6650"))
+                let! (client: PulsarClient) = builder().ServiceInfoProvider(provider).BuildAsync()
+                client.ServiceInfo.ServiceUrl |> Expect.equal "" "pulsar://localhost:6650"
+                do! client.CloseAsync()
+            }
+
+            test "Build throws when ServiceUrl and ServiceInfoProvider are configured together" {
+                let provider = ManualServiceInfoProvider(ServiceInfo("pulsar://localhost:6650"))
+                fun() -> builder().ServiceUrl("pulsar://localhost:6650").ServiceInfoProvider(provider).BuildAsync() |> ignore
+                |> Expect.throwsWithMessage<ArgumentException>
+                    "ServiceUrl and ServiceInfoProvider cannot be configured together. (Parameter 'config')"
             }
 
             test "Http lookup authentication authDataProvider" {

--- a/tests/UnitTests/Api/ServiceInfoTests.fs
+++ b/tests/UnitTests/Api/ServiceInfoTests.fs
@@ -1,0 +1,30 @@
+namespace Pulsar.Client.UnitTests.Api
+
+open System
+open Expecto
+open Expecto.Flip
+open Pulsar.Client.Api
+open Pulsar.Client.UnitTests
+
+module ServiceInfoTests =
+
+    [<Tests>]
+    let tests =
+        testList "ServiceInfoTests" [
+            test "ServiceInfo parses url into scheme and addresses" {
+                let serviceInfo = ServiceInfo("pulsar://host1:6650,host2:6651/path")
+
+                serviceInfo.Scheme |> Expect.equal "" "pulsar"
+                serviceInfo.UseTls |> Expect.equal "" false
+                serviceInfo.ServiceAddresses.Length |> Expect.equal "" 2
+                serviceInfo.ServiceAddresses[0].Host |> Expect.equal "" "host1"
+                serviceInfo.ServiceAddresses[1].Host |> Expect.equal "" "host2"
+            }
+
+            test "ServiceInfo accepts explicit tls override" {
+                let serviceInfo = ServiceInfo("pulsar://host1:6650", Authentication.AuthenticationDisabled, null, null, true)
+
+                serviceInfo.UseTls |> Expect.equal "" true
+            }
+        ]
+

--- a/tests/UnitTests/Internal/DefaultServiceInfoProviderTests.fs
+++ b/tests/UnitTests/Internal/DefaultServiceInfoProviderTests.fs
@@ -1,0 +1,57 @@
+namespace Pulsar.Client.UnitTests.Internal
+
+open System
+open Expecto
+open Expecto.Flip
+open Pulsar.Client.Api
+open Pulsar.Client.Internal
+open Pulsar.Client.UnitTests
+
+module DefaultServiceInfoProviderTests =
+
+    type private ManualServiceInfoProvider(initial: ServiceInfo) =
+        inherit ServiceInfoProvider()
+
+        let mutable onUpdate = ignore
+
+        member _.Update(serviceInfo: ServiceInfo) =
+            onUpdate serviceInfo
+
+        override _.InitialServiceInfo() = initial
+
+        override _.Initialize(callback) =
+            onUpdate <- callback
+
+    [<Tests>]
+    let tests =
+        testList "DefaultServiceInfoProviderTests" [
+            test "Default provider maps config to ServiceInfo" {
+                let config =
+                    { PulsarClientConfiguration.Default with
+                        ServiceUrl = "pulsar://localhost:6650"
+                        UseTls = true
+                        Authentication = AuthenticationFactory.Token("token") }
+
+                let provider = DefaultServiceInfoProvider(config)
+                let serviceInfo = provider.InitialServiceInfo()
+
+                serviceInfo.ServiceUrl |> Expect.equal "" "pulsar://localhost:6650"
+                serviceInfo.UseTls |> Expect.equal "" true
+                serviceInfo.Authentication.GetAuthMethodName() |> Expect.equal "" "token"
+            }
+
+            testTask "PulsarClient exposes updated service info from provider" {
+                let provider = ManualServiceInfoProvider(ServiceInfo("pulsar://localhost:6650"))
+                let client =
+                    PulsarClient(
+                        { PulsarClientConfiguration.Default with
+                            ServiceInfoProvider = Some provider })
+
+                let updatedServiceInfo = ServiceInfo("http://localhost:8080")
+                provider.Update(updatedServiceInfo)
+
+                client.ServiceInfo.ServiceUrl |> Expect.equal "" "http://localhost:8080"
+                client.ServiceInfo.Scheme |> Expect.equal "" "http"
+                do! client.CloseAsync()
+            }
+        ]

--- a/tests/UnitTests/Internal/DefaultServiceInfoProviderTests.fs
+++ b/tests/UnitTests/Internal/DefaultServiceInfoProviderTests.fs
@@ -28,16 +28,32 @@ module DefaultServiceInfoProviderTests =
             test "Default provider maps config to ServiceInfo" {
                 let config =
                     { PulsarClientConfiguration.Default with
-                        ServiceUrl = "pulsar://localhost:6650"
+                        ServiceAddresses = [ Uri("pulsar://localhost:6650") ]
                         UseTls = true
                         Authentication = AuthenticationFactory.Token("token") }
 
                 let provider = DefaultServiceInfoProvider(config)
                 let serviceInfo = provider.InitialServiceInfo()
 
-                serviceInfo.ServiceUrl |> Expect.equal "" "pulsar://localhost:6650"
+                serviceInfo.ServiceUrl |> Expect.equal "" "pulsar+ssl://localhost:6650"
                 serviceInfo.UseTls |> Expect.equal "" true
                 serviceInfo.Authentication.GetAuthMethodName() |> Expect.equal "" "token"
+            }
+
+            test "Default provider builds canonical http service url from config" {
+                let config =
+                    { PulsarClientConfiguration.Default with
+                        ServiceAddresses =
+                            [ Uri("http://localhost:8080")
+                              Uri("http://localhost:8081") ]
+                        Scheme = "http" }
+
+                let provider = DefaultServiceInfoProvider(config)
+                let serviceInfo = provider.InitialServiceInfo()
+
+                serviceInfo.ServiceUrl |> Expect.equal "" "http://localhost:8080,localhost:8081"
+                serviceInfo.Scheme |> Expect.equal "" "http"
+                serviceInfo.UseTls |> Expect.equal "" false
             }
 
             testTask "PulsarClient exposes updated service info from provider" {

--- a/tests/UnitTests/Internal/EndPointResolverTests.fs
+++ b/tests/UnitTests/Internal/EndPointResolverTests.fs
@@ -19,12 +19,12 @@ let tests =
         test "Resolver throws exception for empty address list" {
             Expect.throwsWithMessage<ArgumentException>
                 "Addresses list could not be empty. (Parameter 'addresses')"
-                (fun() -> EndPointResolver([]) |> ignore )
+                (fun() -> EndPointResolver(fun () -> []).Resolve() |> ignore)
         }
 
         test "Resolver works with single address" {
             let address = Uri("pulsar://host1:6650")
-            let resolver = EndPointResolver([address])
+            let resolver = EndPointResolver(fun () -> [address])
 
             resolver.Resolve() |> checkEndPointBy address
             resolver.Resolve() |> checkEndPointBy address
@@ -34,7 +34,7 @@ let tests =
             let address1 = Uri("pulsar://host1:6650")
             let address2 = Uri("pulsar://host2:6650")
             let address3 = Uri("pulsar://host3:6650")
-            let resolver = EndPointResolver([address1; address2; address3])
+            let resolver = EndPointResolver(fun () -> [address1; address2; address3])
 
             resolver.Resolve() |> checkEndPointBy address1
             resolver.Resolve() |> checkEndPointBy address2
@@ -43,9 +43,9 @@ let tests =
             resolver.Resolve() |> checkEndPointBy address2
         }
 
-        test "Dynamic resolver reads updated addresses" {
+        test "Resolver reads updated addresses" {
             let mutable addresses = [ Uri("pulsar://host1:6650") ]
-            let resolver = DynamicEndPointResolver(fun () -> addresses)
+            let resolver = EndPointResolver(fun () -> addresses)
 
             resolver.Resolve() |> checkEndPointBy addresses[0]
 

--- a/tests/UnitTests/Internal/EndPointResolverTests.fs
+++ b/tests/UnitTests/Internal/EndPointResolverTests.fs
@@ -42,4 +42,16 @@ let tests =
             resolver.Resolve() |> checkEndPointBy address1
             resolver.Resolve() |> checkEndPointBy address2
         }
+
+        test "Dynamic resolver reads updated addresses" {
+            let mutable addresses = [ Uri("pulsar://host1:6650") ]
+            let resolver = DynamicEndPointResolver(fun () -> addresses)
+
+            resolver.Resolve() |> checkEndPointBy addresses[0]
+
+            addresses <- [ Uri("pulsar://host2:6650"); Uri("pulsar://host3:6650") ]
+
+            resolver.Resolve() |> checkEndPointBy addresses[1]
+            resolver.Resolve() |> checkEndPointBy addresses[0]
+        }
     ]

--- a/tests/UnitTests/UnitTests.fsproj
+++ b/tests/UnitTests/UnitTests.fsproj
@@ -19,11 +19,13 @@
     <Compile Include="Common\ToolsTests.fs" />
     <Compile Include="Common\MessageTests.fs" />
     <Compile Include="Api\ServiceUriTests.fs" />
+    <Compile Include="Api\ServiceInfoTests.fs" />
     <Compile Include="Api\ConfigurationTests.fs" />
     <Compile Include="Api\ConsumerBuilderTests.fs" />
     <Compile Include="Api\ProducerBuilderTests.fs" />
     <Compile Include="Api\PulsarClientBuilderTests.fs" />
     <Compile Include="Internal\EndPointResolverTests.fs" />
+    <Compile Include="Internal\DefaultServiceInfoProviderTests.fs" />
     <Compile Include="Internal\CompressionCodecTests.fs" />
     <Compile Include="Internal\AcknowledgmentsGroupingTrackerTests.fs" />
     <Compile Include="Internal\ManualInvokeScheduler.fs" />


### PR DESCRIPTION
### Motivation

This change brings the `ServiceInfo` and `ServiceInfoProvider` failover design from `pulsar-client-cpp` into `pulsar-client-dotnet`. The goal is to let the .NET client switch to updated cluster endpoints and connection settings at runtime without rebuilding producers, consumers, or the client itself.

### Modifications

- added the new public failover abstractions `ServiceInfo` and `ServiceInfoProvider`
- extended `PulsarClientConfiguration` and `PulsarClientBuilder` to support provider-driven client initialization while preserving the existing `ServiceUrl(...)` entry point
- introduced `ServiceInfoManager` and `DefaultServiceInfoProvider` to hold the current service snapshot and map static configuration into an initial `ServiceInfo`
- updated `PulsarClient` to expose the current `ServiceInfo`, initialize the provider callback pipeline, and dispose provider-managed resources on shutdown
- changed connection and lookup plumbing so `ConnectionPool`, `BinaryLookupService`, `HttpLookupService`, `PulsarHttpClient`, and `ClientCnx` read from the current `ServiceInfo` instead of assuming startup-time addresses and authentication are immutable
- kept a stable lookup facade through `DynamicLookupService` so existing producer, consumer, and reconnect flows can transparently dispatch to binary or HTTP lookup based on the current service scheme
- refactored endpoint resolution so `EndPointResolver` works against a dynamic address provider and supports runtime address updates without a separate resolver type
- added white-box unit coverage for builder validation, default provider behavior, service info exposure, and dynamic endpoint resolution
@[RobertIndie](https://github.com/RobertIndie/pulsar-client-dotnet/commits?author=RobertIndie)
RobertIndie committed now